### PR TITLE
Allow connection-retry options customization

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ class Watcher extends EventEmitter {
   }
 }
 
-async function newWatcher ({ connectionString, channel = 'casbin' }) {
-  const subscriber = createSubscriber({ connectionString })
+async function newWatcher ({ connectionString, channel = 'casbin' }, options) {
+  const subscriber = createSubscriber({ connectionString }, options)
   await subscriber.connect()
   await subscriber.listenTo(channel)
 


### PR DESCRIPTION
The default connection retry in `pg-listen` times out after 3secs. `pg-listen` allows customizing the connection retry options. However, this package `casbin-pg-watcher` did not expose that option. This PR allows passing the custom connection retry options, so that below kind of error can be avoided:

````
Unhandled Rejection Error: Re-initializing the PostgreSQL notification client after connection loss failed: Stopping PostgreSQL reconnection attempts after 3000ms timeout has been reached.
    at \node_modules\pg-listen\dist\index.js:108:47
    at step (\node_modules\pg-listen\dist\index.js:43:23)
    at Object.next (\node_modules\pg-listen\dist\index.js:24:53)
    at step (\node_modules\pg-listen\dist\index.js:28:139)
    at Object.next (\node_modules\pg-listen\dist\index.js:24:53)
    at fulfilled (\node_modules\pg-listen\dist\index.js:15:58)
````