### PR TITLE
refactor: support pg connection objects

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,8 +51,8 @@ class Watcher extends EventEmitter {
   }
 }
 
-async function newWatcher ({ connectionString, channel = 'casbin' }) {
-  const subscriber = createSubscriber({ connectionString })
+async function newWatcher ({ channel = 'casbin', ...connectionConfig }) {
+  const subscriber = createSubscriber(connectionConfig)
   await subscriber.connect()
   await subscriber.listenTo(channel)
 

--- a/test.js
+++ b/test.js
@@ -83,3 +83,17 @@ test('tracks closed properly', async (t) => {
   watcher.close()
   t.is(watcher.closed, true)
 })
+
+test('supports connection object', async (t) => {
+  const watcher = await newWatcher({
+    host: 'localhost',
+    port: 5432,
+    user: 'postgres',
+    password: 'postgres',
+    database: 'postgres'
+  })
+
+  t.is(await watcher.update(), true)
+
+  watcher.close()
+})


### PR DESCRIPTION
Right now you can only connect to Postgres by passing a `connectionString`. Ideally you should be able to connect to Postgres using the same [connection object](https://node-postgres.com/features/connecting#programmatic) that you can pass to `node-postres` or `pg-listen`.